### PR TITLE
GUI programming typo and refactor examples to if __name__ == __main__ notation

### DIFF
--- a/_sources/GUIandEventDrivenProgramming/03_widgets.rst
+++ b/_sources/GUIandEventDrivenProgramming/03_widgets.rst
@@ -52,23 +52,23 @@ The following two charts list the standard, pre-defined widgets in the
 ``tkinter`` module.
 
 The following widgets are used for user input. In some cases you have a
-choice between the ``tk`` and ``tkk`` versions. In other cases you must
+choice between the ``tk`` and ``ttk`` versions. In other cases you must
 use the ``tk`` version because the equivalent ``ttk`` versions don't exist.
 
 =======================================  ==============================================================
 Widget                                   Purpose
 =======================================  ==============================================================
-``tk.Button``, ``tkk.Button``            Execute a specific task; a “do this now” command.
+``tk.Button``, ``ttk.Button``            Execute a specific task; a “do this now” command.
 ``tk.Menu``                              Implements toplevel, pulldown, and popup menus.
-``tkk.Menubutton``                       Displays popup or pulldown menu items when activated.
+``ttk.Menubutton``                       Displays popup or pulldown menu items when activated.
 ``tk.OptionMenu``                        Creates a popup menu, and a button to display it.
 ``tk.Entry``, ``ttk.Entry``              Enter one line of text.
 ``tk.Text``                              Display and edit formatted text, possibly with multiple lines.
-``tk.Checkbutton``, ``tkk.Checkbutton``  Set on-off, True-False selections.
-``tk.Radiobutton``, ``tkk.Radiobutton``  Allow one-of-many selections.
+``tk.Checkbutton``, ``ttk.Checkbutton``  Set on-off, True-False selections.
+``tk.Radiobutton``, ``ttk.Radiobutton``  Allow one-of-many selections.
 ``tk.Listbox``                           Choose one or more alternatives from a list.
-``tkk.Combobox``                         Combines a text field with a pop-down list of values.
-``tk.Scale``, ``tkk.Scale``              Select a numerical value by moving a “slider” along a scale.
+``ttk.Combobox``                         Combines a text field with a pop-down list of values.
+``tk.Scale``, ``ttk.Scale``              Select a numerical value by moving a “slider” along a scale.
 =======================================  ==============================================================
 
 The following figure shows examples of these widgets. You can download
@@ -84,10 +84,10 @@ The following ``widgets`` display information to a user, but have no user intera
 ============================  ================================================
 Widget                        Purpose
 ============================  ================================================
-``tk.Label``, ``tkk.Label``   Display static text or an image.
+``tk.Label``, ``ttk.Label``   Display static text or an image.
 ``tk.Message``                Display static multi-line text.
-``tkk.Separator``             Displays a horizontal or vertical separator bar.
-``tkk.Progressbar``           Shows the status of a long-running operation.
+``ttk.Separator``             Displays a horizontal or vertical separator bar.
+``ttk.Progressbar``           Shows the status of a long-running operation.
 ``ttk.Treeview``              Displays a hierarchical collection of items.
 ============================  ================================================
 
@@ -110,14 +110,14 @@ creating a ``Tk`` object:
 
 Then you create widgets and add them to the window's widget
 hierarchy. For example, to create a button you would call either the
-``tk`` or the ``tkk`` ``Button`` method and send the ``application_window``
+``tk`` or the ``ttk`` ``Button`` method and send the ``application_window``
 as the first argument:
 
 .. code-block:: python
 
   cmd_button = tk.Button(application_window, text="Example")
   # or
-  cmd_button = tkk.Button(application_window, text="Example")
+  cmd_button = ttk.Button(application_window, text="Example")
 
 The parameters needed to correctly create each widget varies, so you will need to
 refer to the Python documentation for each specific widget type. As of fall

--- a/_sources/GUIandEventDrivenProgramming/04_layout_managers.rst
+++ b/_sources/GUIandEventDrivenProgramming/04_layout_managers.rst
@@ -154,7 +154,7 @@ Here is an example ``pack`` command for a button widget:
 .. code-block:: python
 
   my_button = tk.Button(application_window, text="Example")
-  my_button.grid(side=tk.TOP, fill=tk.Y, expand=True, pady=10)
+  my_button.pack(side=tk.TOP, fill=tk.Y, expand=True, pady=10)
 
 To accomplish a desired interface design using a ``pack`` ``layout manager``
 is typically a process of experimentation. Don't expect to get your desired

--- a/_sources/GUIandEventDrivenProgramming/05_widget_grouping.rst
+++ b/_sources/GUIandEventDrivenProgramming/05_widget_grouping.rst
@@ -24,11 +24,11 @@ they are the parent widget of a group of related widgets.
 ============================  =============================================================================
 Widget                        Purpose
 ============================  =============================================================================
-``tk.Frame``, ``tkk.Frame``   Create a container for a set of widgets to be displayed as a unit.
-``tkk.LabelFrame``            Group a number of related widgets using a border and a title.
+``tk.Frame``, ``ttk.Frame``   Create a container for a set of widgets to be displayed as a unit.
+``ttk.LabelFrame``            Group a number of related widgets using a border and a title.
 ``tk.PanedWindow``            Group one or more widgets into “panes”, where the "panes"
                               can be re-sized by the user by dragging separator lines.
-``tkk.Notebook``              A tabbed set of frames, only one of which is visible at any given time.
+``ttk.Notebook``              A tabbed set of frames, only one of which is visible at any given time.
 ============================  =============================================================================
 
 Widgets are always organized as a hierarchy, where the main

--- a/_sources/GUIandEventDrivenProgramming/08_gui_program_structure.rst
+++ b/_sources/GUIandEventDrivenProgramming/08_gui_program_structure.rst
@@ -80,6 +80,13 @@ variables!
   import tkinter as tk
   from tkinter import ttk
 
+  def main():
+      # Create the entire GUI program
+      program = CounterProgram()
+
+      # Start the GUI event loop
+      program.window.mainloop()
+
   class CounterProgram:
 
       def __init__(self):
@@ -102,11 +109,8 @@ variables!
       def increment_counter(self):
           self.my_counter['text'] = str(int(self.my_counter['text']) + 1)
 
-  # Create the entire GUI program
-  program = CounterProgram()
-
-  # Start the GUI event loop
-  program.window.mainloop()
+  if __name__ == "__main__":
+      main()
 
 Notice the following about this design:
 
@@ -115,7 +119,7 @@ Notice the following about this design:
   by a call to ``create_widgets``.
 * The event handler, ``increment_counter`` can access the label
   ``self.my_counter`` using the object's attributes.
-* The code at "global scope" creates an instance of the class ``CounterProgram`` and
+* The code creates an instance of the class ``CounterProgram`` and
   starts the GUI event-loop.
 
 It is recommended that you develop all of your GUI programs as Python Classes.

--- a/_sources/GUIandEventDrivenProgramming/11_gui_program_example.rst
+++ b/_sources/GUIandEventDrivenProgramming/11_gui_program_example.rst
@@ -62,6 +62,14 @@ window it covers. Here is a basic start for our whack-a-mole game (`whack_a_mole
 
 .. code-block:: python
 
+
+  def main():
+      # Create the entire GUI program
+      program = WhackAMole()
+
+      # Start the GUI event loop
+      program.window.mainloop()
+
   class WhackAMole:
 
       def __init__(self):
@@ -77,11 +85,8 @@ window it covers. Here is a basic start for our whack-a-mole game (`whack_a_mole
 
           return mole_frame, status_frame
 
-  # Create the GUI program
-  program = WhackAMole()
-
-  # Start the GUI event loop
-  program.window.mainloop()
+  if __name__ == "__main__":
+      main()
 
 Step 3: Incrementally add appropriate widgets to each frame. Don't attempt
 to add all the widgets at once. The initial design conceptualized the moles
@@ -94,6 +99,13 @@ later.  (`whack_a_mole_v2.py`_)
 
   import tkinter as tk
   from tkinter import PhotoImage
+
+  def main():
+      # Create the entire GUI program
+      program = WhackAMole()
+
+      # Start the GUI event loop
+      program.window.mainloop()
 
   class WhackAMole:
       NUM_MOLES_ACROSS = 4
@@ -129,11 +141,8 @@ later.  (`whack_a_mole_v2.py`_)
 
           return mole_buttons
 
-  # Create the GUI program
-  program = WhackAMole()
-
-  # Start the GUI event loop
-  program.window.mainloop()
+  if __name__ == "__main__":
+      main()
 
 Continue to add appropriate widgets for the right frame. The final result is
 shown below, but recognize that it was developed little by little.
@@ -144,6 +153,12 @@ shown below, but recognize that it was developed little by little.
   import tkinter as tk
   from tkinter import PhotoImage
 
+  def main():
+      # Create the entire GUI program
+      program = WhackAMole()
+
+      # Start the GUI event loop
+      program.window.mainloop()
 
   class WhackAMole:
       STATUS_BACKGROUND = "white"
@@ -219,11 +234,8 @@ shown below, but recognize that it was developed little by little.
 
           return hit_counter, miss_counter, start_button
 
-  # Create the GUI program
-  program = WhackAMole()
-
-  # Start the GUI event loop
-  program.window.mainloop()
+  if __name__ == "__main__":
+      main()
 
 Step 4: Create a callback function for each event that will cause something
 to happen in your program. Stub these functions out with a single print
@@ -236,6 +248,12 @@ the Python console. (`whack_a_mole_v4.py`_)
   import tkinter as tk
   from tkinter import PhotoImage
 
+  def main():
+      # Create the entire GUI program
+      program = WhackAMole()
+
+      # Start the GUI event loop
+      program.window.mainloop()
 
   class WhackAMole():
       STATUS_BACKGROUND = "white"
@@ -331,11 +349,8 @@ the Python console. (`whack_a_mole_v4.py`_)
       def quit(self):
           print("quit button hit")
 
-  # Create the GUI program
-  program = WhackAMole()
-
-  # Start the GUI event loop
-  program.window.mainloop()
+  if __name__ == "__main__":
+      main()
 
 Step 5: Add appropriate functionality to the callback functions. This is
 where the functional logic of your particular application resides. In the
@@ -362,6 +377,12 @@ quitting. The end result is shown below. (`whack_a_mole_v5.py`_)
   from tkinter import messagebox
   from random import randint
 
+  def main():
+      # Create the entire GUI program
+      program = WhackAMole()
+
+      # Start the GUI event loop
+      program.window.mainloop()
 
   class WhackAMole:
       STATUS_BACKGROUND = "white"
@@ -552,11 +573,8 @@ quitting. The end result is shown below. (`whack_a_mole_v5.py`_)
           if really_quit:
               self.window.destroy()
 
-  # Create the GUI program
-  program = WhackAMole()
-
-  # Start the GUI event loop
-  program.window.mainloop()
+  if __name__ == "__main__":
+      main()
 
 Summary
 -------


### PR DESCRIPTION
Three commits:  One is a typo where "grid" is used instead of "pack."  The other two are example code that previously did not have the if __name__ == "__main__" notation. 

Added fourth commit.  Typo, changed tkk to ttk.

All of these changes are in the GUI lessons that a previous instructor developed at our school.