### PR TITLE
Setting input choose options to be consistent across questions

### DIFF
--- a/_sources/SimplePythonData/Input.rst
+++ b/_sources/SimplePythonData/Input.rst
@@ -99,8 +99,8 @@ The result is referred to by ``total_secs``.  Now, each time you run the program
 
     :click-incorrect:seconds:endclick: = input("Please enter the number of seconds you wish to convert")
 
-    :click-correct:hours:endclick: = int(seconds) // :click-incorrect:3600:endclick:
-    :click-correct:total_secs:endclick: = int(seconds) 
+    :click-correct:hours:endclick: = int(:click-incorrect:seconds:endclick:) // 3600
+    :click-correct:total_secs:endclick: = int(:click-incorrect:seconds:endclick:)
     :click-correct:secs_still_remaining:endclick: = :click-correct:total_secs:endclick: % 3600
     print(:click-correct:secs_still_remaining:endclick:)
 
@@ -109,10 +109,10 @@ The result is referred to by ``total_secs``.  Now, each time you run the program
     :iscode:
     :feedback:
 
-    :click-correct:seconds:endclick: = input(:click-incorrect:"Please enter the number of seconds you wish to convert":endclick:)
+    :click-correct:seconds:endclick: = input("Please enter the number of seconds you wish to convert")
 
-    :click-incorrect:hours:endclick: = int(:click-correct:seconds:endclick:) // :click-incorrect:3600:endclick:
-    :click-incorrect:total_secs:endclick: = int(seconds) 
+    :click-incorrect:hours:endclick: = int(:click-correct:seconds:endclick:) // 3600
+    :click-incorrect:total_secs:endclick: = int(:click-correct:seconds:endclick:)
     :click-incorrect:secs_still_remaining:endclick: = :click-incorrect:total_secs:endclick: % 3600
     print(:click-incorrect:secs_still_remaining:endclick:)
 


### PR DESCRIPTION
This pull request resolves issue #94 
There was confusion in the answer to the last two questions in Input, because of the fact that not all variables were selectable and not all selectable text was the same across questions. 

This should remove the confusion that was stated in the referenced issue.