### PR TITLE
Update Exercises.rst

### DIFF
--- a/_sources/Lists/Exercises.rst
+++ b/_sources/Lists/Exercises.rst
@@ -201,7 +201,7 @@ Exercises
             .. activecode:: lst_q5_answer
 
                 def max(lst):
-                    max = 0
+                    max = lst[0]
                     for e in lst:
                         if e > max:
                             max = e


### PR DESCRIPTION
Fix exercise on finding the max so that it will work over all integers, not just for lists with positive numbers. This fix should work since the problem states that the input `lst` will be non-empty.