### PR TITLE
fixed the typo in 19.4 section

### DIFF
--- a/_sources/Inheritance/04-ReuseThroughComposition.rst
+++ b/_sources/Inheritance/04-ReuseThroughComposition.rst
@@ -39,7 +39,7 @@ For example, our LabeledPoint example could have been implemented as follows:
     print(p.distanceFromOrigin())
 
 The first thing to notice about this version of LabeledPoint 
-does not inherit from Point. Instead, its constructor 
+is that it does not inherit from Point. Instead, its constructor 
 instantiates a Point and stores a reference to it in its ``point`` 
 instance variable so that it can be used by the other methods.
 


### PR DESCRIPTION
Fixes issue #206 which was a typo in section 19.4. The text states: "The first thing to notice about this version of LabeledPoint does not inherit from Point."  However, it should be "The first thing to notice about this version of LabeledPoint is that it does not inherit from Point."